### PR TITLE
Add Rust in Chromium to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ open an issue, be nice
 * [uwuify-mdbook](https://github.com/alyti/uwuify-mdbook): an mdbook pre-processor for all your uwuify needs
 * [uwu-joke](https://github.com/joshualeejunyi/uwu-joke): automatically uwuifies typed text and text copied to your clipboard
 * [discordbot (go)](https://github.com/angch/discordbot): discord (and telegram and slack) bot for fun
+* [Rust in Chromium](https://google.github.io/comprehensive-rust/chromium.html): an exercise in integrating Rust with Chromium
 * let me know if u make a project with uwuify! i appreciate u all!
 
 ### references


### PR DESCRIPTION
I hope this is appropriate here: we used your library as an exercise for the [Rust in Chromium class](https://google.github.io/comprehensive-rust/chromium.html) of Comprehensive Rust.